### PR TITLE
fix: AreaHighlight props

### DIFF
--- a/src/components/AreaHighlight.tsx
+++ b/src/components/AreaHighlight.tsx
@@ -1,13 +1,13 @@
 import React, { Component } from "react";
 
-import { Rnd } from "react-rnd";
+import { Rnd, Props as RndProps } from "react-rnd";
 import { getPageFromElement } from "../lib/pdfjs-dom";
 
 import "../style/AreaHighlight.css";
 
 import type { LTWHP, ViewportHighlight } from "../types";
 
-interface Props {
+interface Props extends RndProps {
   highlight: ViewportHighlight;
   onChange: (rect: LTWHP) => void;
   isScrolledTo: boolean;


### PR DESCRIPTION
Need to add these props to AreaHighlight to prevent resizing/moving the highlight after creation for https://tryargus.atlassian.net/browse/AM-4278

<img width="576" alt="Screenshot 2024-07-01 at 3 11 18 PM" src="https://github.com/ArgusRegLabs/react-pdf-highlighter/assets/164904385/0283af96-be0b-4f89-93db-42e8786b97fa">

