### PR TITLE
feat: pdfviewer onLoad prop

### DIFF
--- a/src/components/PdfLoader.tsx
+++ b/src/components/PdfLoader.tsx
@@ -12,6 +12,7 @@ interface Props {
   errorMessage?: JSX.Element;
   children: (pdfDocument: PDFDocumentProxy) => JSX.Element;
   onError?: (error: Error) => void;
+  onLoad?: () => void;
   cMapUrl?: string;
   cMapPacked?: boolean;
 }
@@ -83,6 +84,7 @@ export class PdfLoader extends Component<Props, State> {
           cMapUrl,
           cMapPacked,
         }).promise.then((pdfDocument) => {
+          this.props.onLoad?.();
           this.setState({ pdfDocument });
         });
       })


### PR DESCRIPTION
so we can hide the annotation help icon while the document is loading (looks weird when it's just the icon by itself)