### PR TITLE
fix: disable annotations

### DIFF
--- a/src/components/PdfHighlighter.tsx
+++ b/src/components/PdfHighlighter.tsx
@@ -27,7 +27,7 @@ import {
 } from "../lib/pdfjs-dom";
 import { scaledToViewport, viewportToScaled } from "../lib/coordinates";
 import MouseSelection from "./MouseSelection";
-import type { PDFDocumentProxy } from "pdfjs-dist";
+import { AnnotationMode, type PDFDocumentProxy } from "pdfjs-dist";
 import TipContainer from "./TipContainer";
 import { createRoot, Root } from "react-dom/client";
 import debounce from "lodash.debounce";
@@ -183,6 +183,7 @@ export class PdfHighlighter<T_HT extends IHighlight> extends PureComponent<
         removePageBorders: true,
         linkService: this.linkService,
         l10n: NullL10n,
+        annotationMode: AnnotationMode.DISABLE,
       });
 
     this.linkService.setDocument(pdfDocument);


### PR DESCRIPTION
https://aercompliance.slack.com/archives/C069ZPM9Q3D/p1721064296314449

this PR disabled pdf annotation rendering for annotations that are saved in the actual PDF. this is so users dont get them confused with the annotations from AI or ones they add thru the app